### PR TITLE
feat(seo): add OG tags, JSON-LD schema, and llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,39 @@
+# Jaime Vega — jvega.dev
+
+> Personal portfolio of Jaime Vega, Front-end Engineer and Tech Lead based in Amsterdam.
+
+Jaime Vega is a senior front-end engineer and tech lead with over a decade of experience
+building large-scale web applications. He has worked at ING and Thunderhead, leading UI
+engineering teams and driving frontend technology strategy.
+
+## Pages
+
+- [Home](https://www.jvega.dev): Landing page with contact information.
+- [About Me](https://www.jvega.dev/about-me): Professional background, work experience, skills, and education.
+- [About This Page](https://www.jvega.dev/about-this-page): Technology stack used to build jvega.dev.
+
+## Contact
+
+- Email: jaime.vega@gmail.com
+- LinkedIn: https://linkedin.com/in/jvegadev
+- GitHub: https://github.com/jhuesos
+- Website: https://www.jvega.dev
+
+## Skills
+
+JavaScript, TypeScript, React, Node.js, Vue, Web Components, Progressive Web Apps (PWA),
+Redux, HTML, CSS, CSS Modules, Webpack, Git
+
+## Experience
+
+- Front-End Engineer Consultant — ING (2019)
+- Front-End Engineer / Tech Lead — ING (2016–2018)
+- Team Lead / Scrum Master — Thunderhead (2015–2016)
+- Senior Front-End Engineer — Thunderhead (2012–2016)
+- Lead Front-End Engineer — Casengo (2011–2012)
+- Full Stack Engineer — Livecom (2011)
+- Web Development / IT Support — Feyecon (2010–2011)
+
+## Education
+
+Master's degree in Computer Engineering — University of Las Palmas de Gran Canaria, Spain (2010)

--- a/src/app/about-me/metadata.ts
+++ b/src/app/about-me/metadata.ts
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import { ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata';
+
+export const metadata: Metadata = {
+  title: 'About Me',
+  description:
+    'Learn about Jaime Vega, front-end engineer and tech lead from Amsterdam.',
+  openGraph: {
+    type: 'profile',
+    firstName: 'Jaime',
+    lastName: 'Vega',
+    username: 'jvegadev',
+    siteName: SITE_NAME,
+    title: 'About Me | Jaime Vega',
+    description:
+      'Learn about Jaime Vega, front-end engineer and tech lead from Amsterdam.',
+    url: `${SITE_URL}/about-me`,
+    images: [ogImage],
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'About Me | Jaime Vega',
+    description:
+      'Learn about Jaime Vega, front-end engineer and tech lead from Amsterdam.',
+    images: [ogImage.url],
+  },
+};

--- a/src/app/about-me/page.tsx
+++ b/src/app/about-me/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import Image from 'next/image';
 import { Chip } from '@/components/Chip/Chip';
 import { Disclaimer } from '@/components/Disclaimer/Disclaimer';
@@ -6,11 +5,7 @@ import { Header } from '@/components/Header/Header';
 import { ProgressBar } from '@/components/ProgressBar/ProgressBar';
 import styles from './page.module.css';
 
-export const metadata: Metadata = {
-  title: 'About Me',
-  description:
-    'Learn about Jaime Vega, front-end engineer and tech lead from Amsterdam.',
-};
+export { metadata } from './metadata';
 
 export default function AboutMe() {
   return (

--- a/src/app/about-this-page/metadata.ts
+++ b/src/app/about-this-page/metadata.ts
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata';
+
+export const metadata: Metadata = {
+  title: 'About This Page',
+  description:
+    'Learn about the technology stack and tools used to build jvega.dev.',
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    title: 'About This Page | Jaime Vega',
+    description:
+      'Learn about the technology stack and tools used to build jvega.dev.',
+    url: `${SITE_URL}/about-this-page`,
+    images: [ogImage],
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'About This Page | Jaime Vega',
+    description:
+      'Learn about the technology stack and tools used to build jvega.dev.',
+    images: [ogImage.url],
+  },
+};

--- a/src/app/about-this-page/page.tsx
+++ b/src/app/about-this-page/page.tsx
@@ -1,12 +1,7 @@
-import type { Metadata } from 'next';
 import { Header } from '@/components/Header/Header';
 import styles from './page.module.css';
 
-export const metadata: Metadata = {
-  title: 'About This Page',
-  description:
-    'Learn about the technology stack and tools used to build jvega.dev.',
-};
+export { metadata } from './metadata';
 
 export default function AboutThisPage() {
   return (

--- a/src/app/layout.metadata.ts
+++ b/src/app/layout.metadata.ts
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import { ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata';
+
+export const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Jaime Vega',
+  url: SITE_URL,
+  email: 'jaime.vega@gmail.com',
+  jobTitle: 'Front-end Engineer & Tech Lead',
+  image: `${SITE_URL}/images/profile-pic-600.jpg`,
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Amsterdam',
+    addressCountry: 'NL',
+  },
+  sameAs: ['https://linkedin.com/in/jvegadev', 'https://github.com/jhuesos'],
+  knowsAbout: [
+    'JavaScript',
+    'TypeScript',
+    'React',
+    'Node.js',
+    'Vue',
+    'Web Components',
+    'Progressive Web Apps',
+    'Redux',
+    'CSS',
+    'HTML',
+  ],
+} as const;
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Jaime Vega - Front-end Engineer & Tech Lead',
+    template: '%s | Jaime Vega',
+  },
+  description:
+    "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
+  metadataBase: new URL(SITE_URL),
+  icons: {
+    icon: '/logo/favicon.ico',
+    apple: '/logo/apple-touch-icon.png',
+  },
+  other: {
+    'theme-color': '#0B8296',
+  },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    title: 'Jaime Vega - Front-end Engineer & Tech Lead',
+    description:
+      "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
+    url: SITE_URL,
+    images: [ogImage],
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Jaime Vega - Front-end Engineer & Tech Lead',
+    description:
+      "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
+    images: [ogImage.url],
+  },
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,31 +1,16 @@
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
-import type { Metadata } from 'next';
 import { Roboto } from 'next/font/google';
+import { jsonLd, metadata } from './layout.metadata';
 import './globals.css';
+
+export { metadata };
 
 const roboto = Roboto({
   subsets: ['latin'],
   weight: ['400', '700'],
   display: 'swap',
 });
-
-export const metadata: Metadata = {
-  title: {
-    default: 'Jaime Vega - Front-end Engineer & Tech Lead',
-    template: '%s | Jaime Vega',
-  },
-  description:
-    "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
-  metadataBase: new URL('https://www.jvega.dev'),
-  icons: {
-    icon: '/logo/favicon.ico',
-    apple: '/logo/apple-touch-icon.png',
-  },
-  other: {
-    'theme-color': '#0B8296',
-  },
-};
 
 export default function RootLayout({
   children,
@@ -35,6 +20,11 @@ export default function RootLayout({
   return (
     <html lang="en" className={roboto.className}>
       <body>
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD schema, no user input
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         {children}
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.metadata.ts
+++ b/src/app/page.metadata.ts
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { ogImage, SITE_NAME, SITE_URL } from '@/lib/metadata';
+
+export const metadata: Metadata = {
+  openGraph: {
+    type: 'website',
+    siteName: SITE_NAME,
+    title: 'Jaime Vega - Front-end Engineer & Tech Lead',
+    description:
+      "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
+    url: SITE_URL,
+    images: [ogImage],
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Jaime Vega - Front-end Engineer & Tech Lead',
+    description:
+      "jvega.dev is Jaime Vega's (front-end engineer and tech lead from Amsterdam) personal website.",
+    images: [ogImage.url],
+  },
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import { Header } from '@/components/Header/Header';
 import styles from './page.module.css';
 
+export { metadata } from './page.metadata';
+
 export default function Home() {
   return (
     <div className={styles.page}>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,15 +4,21 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: 'https://www.jvega.dev',
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
+      changeFrequency: 'weekly',
+      priority: 1.0,
     },
     {
       url: 'https://www.jvega.dev/about-me',
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
+      changeFrequency: 'weekly',
+      priority: 0.8,
     },
     {
       url: 'https://www.jvega.dev/about-this-page',
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
+      changeFrequency: 'weekly',
+      priority: 0.5,
     },
   ];
 }

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,9 @@
+export const SITE_URL = 'https://www.jvega.dev';
+export const SITE_NAME = 'jvega.dev';
+
+export const ogImage = {
+  url: '/images/profile-pic-600.jpg',
+  width: 600,
+  height: 600,
+  alt: 'Jaime Vega — Front-end Engineer & Tech Lead',
+} as const;


### PR DESCRIPTION
- Add Open Graph and Twitter Card metadata to all pages
- Add JSON-LD Person schema (Schema.org) in root layout
- Add public/llms.txt for AI crawler discovery
- Extract metadata into co-located *.metadata.ts files with shared
  constants in src/lib/metadata.ts
- Fix sitemap lastModified to use static dates; set changeFrequency
  to weekly across all routes
